### PR TITLE
chore: added AUR vicinae package to installation docs

### DIFF
--- a/src/app/install/page.mdx
+++ b/src/app/install/page.mdx
@@ -4,15 +4,17 @@ Most direct ways to install Vicinae on your system. If your system is not listed
 
 ## Arch Linux (AUR)
 
-Vicinae is packaged as `vicinae-git` [on the AUR](https://aur.archlinux.org/packages/vicinae-git).
+Vicinae is packaged as `vicinae` [on the AUR](https://aur.archlinux.org/packages/vicinae) and `vicinae-git` [on the AUR](https://aur.archlinux.org/packages/vicinae-git).
 
 You can install it using any AUR helper:
 
 ```bash
-# paru
-paru -S vicinae-git
+yay -S vicinae
+```
 
-# yay
+For git version:
+
+```bash
 yay -S vicinae-git
 ```
 


### PR DESCRIPTION
I created an AUR package named `vicinae`.

The key differences between `vicinae` and `vicinae-git` are:  
- The PKGBUILD uses **GitHub releases** and does **not compile code**.  
- Installs a **systemd service**, **themes**, and the **Vicinae logo** into the system.  

You can find the package here: [vicinae](https://aur.archlinux.org/packages/vicinae)

Updated the docs according to AUR packages.