### PR TITLE
Add fedora install instructions

### DIFF
--- a/src/app/repo-install/page.mdx
+++ b/src/app/repo-install/page.mdx
@@ -73,6 +73,15 @@ extra-substituters = [ "https://vicinae.cachix.org" ];
 extra-trusted-public-keys = [ "vicinae.cachix.org-1:1kDrfienkGHPYbkpNj1mWTr7Fm1+zcenzgTizIcI3oc=" ];
 ```
 
+## Fedora
+
+Vicinae can be installed from the [gvalkov/vicinae](https://copr.fedorainfracloud.org/coprs/gvalkov/vicinae/) Copr repository:
+
+```bash
+dnf copr enable gvalkov/vicinae
+dnf install vicinae
+```
+
 ## Gentoo 
 
 ### jaredallard's overlay


### PR DESCRIPTION
Hello,

I made a vicinae [copr repo](https://copr.fedorainfracloud.org/coprs/gvalkov/vicinae) and added it to the installation instructions page. 

It currently depends on the [quadratech188/cmark-gfm](https://copr.fedorainfracloud.org/coprs/quadratech188/cmark-gfm/) copr repo as vicinae wasn't compiling with `USE_SYSTEM_CMARK_GFM=ON`.

Spec file: https://github.com/gvalkov/copr-packages/blob/main/vicinae/vicinae.spec

Kind regards,
Georgi