### PR TITLE
Add Home Manager settings option to docs and seperate nixos file

### DIFF
--- a/src/app/nixos/page.mdx
+++ b/src/app/nixos/page.mdx
@@ -1,0 +1,92 @@
+import { CodePanel } from '@/components/Code';
+
+# Nixos
+Vicinae is available as a Nix flake but can also be run withou installing. You can use the binaries of the Nix package or enable the systemd service provided by the home-manager module.
+
+## Run Vicinae without installing
+You can test the app directly by using a nix shell
+
+```bash
+nix shell github:vicinaehq/vicinae
+```
+
+## Home Manager module
+
+<Note>
+If you don’t want to compile Vicinae yourself, make sure to enable [Cachix](/nixos#cachix)
+</Note>
+
+```nix
+# flake.nix
+{
+    description = "...";
+    inputs = {
+        vicinae.url = "github:vicinaehq/vicinae"; # tell Nixos where to get Vicinae
+        ...
+    };
+    outputs = {
+        nixpkgs,
+        home-manager,
+        vicinae, # enable the Output
+    }: let
+    system = "...";
+    pkgs = nixpkgs.legacyPackages.${system};
+    in {
+        homeConfigurations."..." = home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+
+            modules = [
+                vicinae.homeManagerModules.default # enable Home Manager
+                ...
+            ];
+        }
+    }
+}
+```
+
+```nix
+# home.nix
+# ...
+{pkgs}:{
+    services.vicinae = {
+        enable = true; # default: false
+        autoStart = true; # default: true
+        package = # specify package to use here. Can be omitted.
+    };
+}
+```
+
+## Cachix
+
+The Vicinae flake is **not** built by Hydra, so it is not cached in cache.nixos.org, like the rest of Nixpkgs.
+Instead of requiring you to build Vicinae every time it updates, we provide a Cachix cache that you can add to your Nix configuration.
+
+```nix
+extra-substituters = [ "https://vicinae.cachix.org" ];
+extra-trusted-public-keys = [ "vicinae.cachix.org-1:1kDrfienkGHPYbkpNj1mWTr7Fm1+zcenzgTizIcI3oc=" ];
+```
+
+## Configuring with Home Manager
+You can configure Vicinae using Home Manager options. Here is an example configuration:
+
+
+
+```nix
+services.vicinae = {
+  enable = true;
+  autoStart = true;
+  settings = {
+      faviconService = "twenty"; # twenty | google | none
+      font.size = 11;
+      popToRootOnClose = false;
+      rootSearch.searchFiles = false;
+      theme.name = "vicinae-dark";
+      window = {
+        csd = true;
+        opacity = 0.95;
+        rounding = 10;
+      };
+   };
+};
+```
+the `theme.name` option can be set to any of the themes that come with Vicinae or a custom theme you have installed. See [the Github](https://github.com/vicinaehq/vicinae/tree/main/extra/themes) for more information on default theme names.

--- a/src/app/repo-install/page.mdx
+++ b/src/app/repo-install/page.mdx
@@ -6,71 +6,17 @@ Most direct ways to install Vicinae on your system. If your system is not listed
 
 Vicinae is available on the Arch User Repository (AUR) in three variants:
 
-- **Source build**  
-  - [vicinae](https://aur.archlinux.org/packages/vicinae) – stable release, compiled from source  
-  - [vicinae-git](https://aur.archlinux.org/packages/vicinae-git) – latest development version, compiled from source  
+- **Source build**
+  - [vicinae](https://aur.archlinux.org/packages/vicinae) – stable release, compiled from source
+  - [vicinae-git](https://aur.archlinux.org/packages/vicinae-git) – latest development version, compiled from source
 
-- **Prebuilt binary**  
-  - [vicinae-bin](https://aur.archlinux.org/packages/vicinae-bin) – stable release, precompiled binary  
+- **Prebuilt binary**
+  - [vicinae-bin](https://aur.archlinux.org/packages/vicinae-bin) – stable release, precompiled binary
 
 You can install Vicinae using your preferred AUR helper.
 
 ```bash
 yay -S vicinae-bin
-```
-
-## Nix (Flake)
-Vicinae is also available as a Nix flake. You can use the binaries of the Nix package or enable the systemd service provided by the home-manager module.
-```bash
-nix shell github:vicinaehq/vicinae
-```
-
-### Home Manager module
-```nix
-# flake.nix
-{
-    description = "...";
-    inputs = {
-        vicinae.url = "github:vicinaehq/vicinae";
-        ...
-    };
-    outputs = {
-        nixpkgs,
-        home-manager,
-        vicinae,
-    }: let
-    system = "...";
-    pkgs = nixpkgs.legacyPackages.${system};
-    in {
-        homeConfigurations."..." = home-manager.lib.homeManagerConfiguration {
-            inherit pkgs;
-
-            modules = [
-                vicinae.homeManagerModules.default
-                ...
-            ];
-        }
-    }
-}
-```
-
-```nix
-# home.nix
-# ...
-{pkgs}:{
-    services.vicinae = {
-        enable = true; # default: false
-        autoStart = true; # default: true
-        package = # specify package to use here. Can be omitted.
-    };
-}
-```
-
-### Nix Binary Cache
-
-```nix
-extra-substituters = [ "https://vicinae.cachix.org" ];
-extra-trusted-public-keys = [ "vicinae.cachix.org-1:1kDrfienkGHPYbkpNj1mWTr7Fm1+zcenzgTizIcI3oc=" ];
 ```
 
 ## Fedora
@@ -82,7 +28,7 @@ dnf copr enable gvalkov/vicinae
 dnf install vicinae
 ```
 
-## Gentoo 
+## Gentoo
 
 ### jaredallard's overlay
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -244,6 +244,7 @@ export const navigation: Array<NavGroup> = [
       { title: 'Build from source', href: '/build' },
       { title: 'Gnome Support', href: '/gnome-support' },
       { title: 'Network and Privacy', href: '/privacy' },
+      { title: 'Nixos', href: '/nixos' },
     ],
   },
   {
@@ -276,15 +277,16 @@ export const navigation: Array<NavGroup> = [
       { title: 'Debug Raycast Extensions', href: '/extensions/debug-raycast' },
       { title: 'API Reference', href: '/extensions/api' },
       { title: 'Create a view command', href: '/extensions/view-command' },
-      { title: 'Create a no-view command', href: '/extensions/no-view-command' }
+      {
+        title: 'Create a no-view command',
+        href: '/extensions/no-view-command',
+      },
     ],
   },
 
   {
     title: 'Contributing',
-    links: [
-      { title: 'Clipboard Server', href: '/contrib/clipboard' },
-    ],
+    links: [{ title: 'Clipboard Server', href: '/contrib/clipboard' }],
   },
 ]
 


### PR DESCRIPTION
Just a few changes to the nixos documentation 

- Separate Nixos file
  - Nixos section in `/repo-install` felt to big with added home manager options
- new home manager `settings` option documentation
- Rewording of some descriptions