### PR TITLE
fix extension preferences type examples

### DIFF
--- a/src/app/extensions/manifest/page.mdx
+++ b/src/app/extensions/manifest/page.mdx
@@ -78,7 +78,7 @@ A preference object looks like this:
 - `name` is the id of the preference, which should remain in a slugified form
 - `title` is the display name of the preference - shown to users
 - `required` if a preference is required and has no default value, Vicinae will explicitly ask the user to supply it before a command can be started.
-- `type` is the type of preference. Right now we mainly support `text`, `password` and `dropdown`. 
+- `type` is the type of preference. Right now we mainly support `textfield`, `password` and `dropdown`. 
 
 If a preference is of type `dropdown` an additional `data` field is expected:
 


### PR DESCRIPTION
The correct type is `textfield` not `text`