### PR TITLE
fix: wrong navigation link for gnome support page

### DIFF
--- a/src/app/clipboard/page.mdx
+++ b/src/app/clipboard/page.mdx
@@ -14,7 +14,7 @@ If you’d like to contribute support for an environment that isn’t yet compat
 |------|-----------|---------|
 | X11 | ❌ | Planned for future implementation |
 | KDE Wayland | ✅ | Uses the `wlr-data-control` protocol |
-| Gnome | ✅ | Using the <a href="https://github.com/dagimg-dot/vicinae-gnome-extension" target="_blank">Vicinae Gnome Extension</a> (See installation [on getting started](/getting-started#gnome-support)) |
+| Gnome | ✅ | Using the <a href="https://github.com/dagimg-dot/vicinae-gnome-extension" target="_blank">Vicinae Gnome Extension</a> (See installation [on Gnome Support](/gnome-support)) |
 | Hyprland | ✅ | |
 | Sway | ✅ | |
 | Niri | ✅ | |

--- a/src/app/window/page.mdx
+++ b/src/app/window/page.mdx
@@ -11,7 +11,7 @@ Window management support can vary depending on the desktop environment or compo
 
 | Name | Supported | Comment |
 |------|-----------|---------|
-| Gnome | ✅ | Using the <a href="https://github.com/dagimg-dot/vicinae-gnome-extension" target="_blank">Vicinae Gnome Extension</a> (See installation [on getting started](/getting-started#gnome-support)) |
+| Gnome | ✅ | Using the <a href="https://github.com/dagimg-dot/vicinae-gnome-extension" target="_blank">Vicinae Gnome Extension</a> (See installation [on Gnome Support](/gnome-support)) |
 | Hyprland | ✅ | Using built-in <a href="https://wiki.hypr.land/Configuring/Using-hyprctl/" target="_blank">IPC</a> |
 | X11 | ❌ | Planned for future implementation |
 | KDE Wayland | ❌ | Planned for future implementation |


### PR DESCRIPTION
- On both clipboard management and window management pages' environment support section the gnome support link was wrong.