### PR TITLE
fix(docs): various typos and grammatical errors

### DIFF
--- a/src/app/build/page.mdx
+++ b/src/app/build/page.mdx
@@ -135,7 +135,7 @@ or are generally not easy to install through traditional means.
 
 The main goal of this is to make pre-built binaries more portable across different distributions that ship different versions of the same package.
 
-For instance, `libprotobuf` updates very often and offers no retro-compatbility. This essentially means that the distributed binaries become outdated as soon as the distribution updates
+For instance, `libprotobuf` updates very often and offers no retro-compatibility. This essentially means that the distributed binaries become outdated as soon as the distribution updates
 its protobuf version. By statically linking against protobuf, we embed a given version of protobuf in the binary, and this specific, local version is the one going to be used for the entire lifetime of the binary.
 
 <Warning>

--- a/src/app/contrib/docs/page.mdx
+++ b/src/app/contrib/docs/page.mdx
@@ -9,7 +9,7 @@ If you are contributing simple documentation or configuration you usually do not
 </Note>
 
 ## Naming and Placement Conventions
-To keep our documentation organized and easy to navigate, the docs are seperated into folders containing either sub-folders (in case there are multiple docs of that type as with the `src/app/extensions` folder) or a `page.mdx` in which the documentation is written.
+To keep our documentation organized and easy to navigate, the docs are separated into folders containing either sub-folders (in case there are multiple docs of that type as with the `src/app/extensions` folder) or a `page.mdx` in which the documentation is written.
 
 ## Adding a new File to the Navigation
 To make your new documentation discoverable, add it to the navigation menu:

--- a/src/app/deeplinks/page.mdx
+++ b/src/app/deeplinks/page.mdx
@@ -1,6 +1,6 @@
 # Deeplinks
 
-Deeplinks is a mechanism allowing your to control Vicinae using the `vicinae://` url scheme. It allows you to toggle the window visibility, launch a specific command, and much more.
+Deeplinks is a mechanism allowing you to control Vicinae using the `vicinae://` url scheme. It allows you to toggle the window visibility, launch a specific command, and much more.
 
 ## Using Deeplinks
 

--- a/src/app/extensions/create/page.mdx
+++ b/src/app/extensions/create/page.mdx
@@ -4,7 +4,7 @@ This page explains how to create your first extension.
 
 ## Requirements
 
-In order to develop /extensions, you will need:
+In order to develop extensions, you will need:
 
 - A working installation of NodeJS (>=20 recommended). If you are on Linux your package manager may have handled that for you already.
 - A npm compatible package manager such as `npm` or `pnpm`. We always use `npm` in our examples.

--- a/src/app/extensions/debug-raycast/page.mdx
+++ b/src/app/extensions/debug-raycast/page.mdx
@@ -39,7 +39,7 @@ Instead, explicitly invoke the `vici` CLI exported from the `@vicinae/api` packa
 npx vici develop
 ```
 
-This should normally work seemlessly as it does for any other extension.
+This should normally work seamlessly as it does for any other extension.
 
 <Note>
 When debugging a Raycast extension, make sure you use exports from the `@raycast/api` package and not from the `@vicinae/api` one. Although mixing them will work, it may yield unexpected results.

--- a/src/app/extensions/introduction/page.mdx
+++ b/src/app/extensions/introduction/page.mdx
@@ -76,10 +76,10 @@ Search automatically works, markdown is automatically formatted, life's great :)
 
 ## Raycast compatibility
 
-Most of the extension stuff is inspired by the way [Raycast](https://developers.raycast.com/) does it, and our long term goal is to be compatible with most existing Raycast extensions.
+Most of the extension stuff is inspired by the way [Raycast](https://developers.raycast.com/) does it, and our long-term goal is to be compatible with most existing Raycast extensions.
 
 For this reason, our API follows the Raycast API very closely but also offers exclusive APIs. Our goal is to be our own thing, not copy everything Raycast is doing.
 
 <Note>
-Since Vicinae is open source and community-driven , we tend to prioritize API features that most users want to see implemented first.
+Since Vicinae is open source and community-driven, we tend to prioritize API features that most users want to see implemented first.
 </Note>

--- a/src/app/extensions/manifest/page.mdx
+++ b/src/app/extensions/manifest/page.mdx
@@ -2,7 +2,7 @@
 
 The extension manifest is an extension of the regular `package.json` format found across most npm-managed Javascript projects.
 
-It contains information about the dependencies to install, but also about extension specific stuff, such as what commands the extension exports, with what preferences, with what arguments, etc...
+It contains information about the dependencies to install, but also about extension-specific stuff, such as what commands the extension exports, with what preferences, with what arguments, etc...
 
 <Warning>
 Our manifest documentation is still incomplete. You can refer to the [Raycast documentation](https://developers.raycast.com/information/manifest) for an exhaustive list of supported keys, as we share the same manifest format.
@@ -105,7 +105,7 @@ If a preference is of type `dropdown` an additional `data` field is expected:
 
 ### Add preferences
 
-To specifiy a set of extension preferences, just fill in the top-level `preferences` array with as many preference objects as you want.
+To specify a set of extension preferences, just fill in the top-level `preferences` array with as many preference objects as you want.
 
 You can do the same for each command inside `commands` to specificy command-local preferences.
 

--- a/src/app/file-search/page.mdx
+++ b/src/app/file-search/page.mdx
@@ -27,7 +27,7 @@ Subsequent indexing is done incrementally and is way less CPU intensive.
 You may be able to start searching for files as the indexing goes through. If nothing shows up after a few minutes, then something probably went wrong and you should let us know.
 
 <Note>
-If the Vicinae server is interruped during file indexing, it is smart enough to know about it and start a new scan on next startup. Note, however, that the index will have to be fully rebuilt from scratch.
+If the Vicinae server is interrupted during file indexing, it is smart enough to know about it and start a new scan on next startup. Note, however, that the index will have to be fully rebuilt from scratch.
 </Note>
 
 ## Search paths
@@ -44,7 +44,7 @@ Adding new search locations might trigger new indexing tasks immediately.
 
 ## Special indexing rules
 
-Current, we have a few special indexing rules in place, mostly as a way to speed up indexing (the defaults may change soon):
+Currently, we have a few special indexing rules in place, mostly as a way to speed up indexing (the defaults may change soon):
 
 - dot files and dot folders are not indexed (will be made configurable)
 - `.gitignore` files are read and considered as they would normally be in a git repository (although we don't use proper gitignore patterns so some complicated ones may not work)

--- a/src/app/launcher-window/page.mdx
+++ b/src/app/launcher-window/page.mdx
@@ -2,7 +2,7 @@ import { FEATURE_REQUEST_URL, VICINAE_GENERAL_SETTINGS_URL } from '@/lib/constan
 
 # Launcher Window
 
-This page documents how to customize the Vicinae launcher window. If you are looking for ways to programatically control the window, consider using [deeplinks](/deeplinks#window-controls). {{ className: 'lead' }}
+This page documents how to customize the Vicinae launcher window. If you are looking for ways to programmatically control the window, consider using [deeplinks](/deeplinks#window-controls). {{ className: 'lead' }}
 
 
 ## Window sizing
@@ -60,4 +60,4 @@ It is possible to change the base font size from within the <a href={VICINAE_GEN
 
 ## Gnome Integration
 
-Since Gnome doesn't natively suppot the layer shell protocol, the launcher window is always a regular floating window. To make it behave like a layer shell window which closes on focus loss, you can use the companion [Vicinae Gnome Extension](https://github.com/dagimg-dot/vicinae-gnome-extension).
+Since Gnome doesn't natively support the layer shell protocol, the launcher window is always a regular floating window. To make it behave like a layer shell window which closes on focus loss, you can use the companion [Vicinae Gnome Extension](https://github.com/dagimg-dot/vicinae-gnome-extension).

--- a/src/app/nixos/page.mdx
+++ b/src/app/nixos/page.mdx
@@ -1,7 +1,7 @@
 import { CodePanel } from '@/components/Code';
 
 # Nixos
-Vicinae is available as a Nix flake but can also be run withou installing. You can use the binaries of the Nix package or enable the systemd service provided by the home-manager module.
+Vicinae is available as a Nix flake but can also be run without installing. You can use the binaries of the Nix package or enable the systemd service provided by the home-manager module.
 
 ## Run Vicinae without installing
 You can test the app directly by using a nix shell

--- a/src/app/privacy/page.mdx
+++ b/src/app/privacy/page.mdx
@@ -9,7 +9,7 @@ Vicinae makes network requests in these specific scenarios:
 - **Favicon loading** - When [favicon loading](/favicon) is enabled (the default), built-in commands fetch favicons for HTTP URLs to use as icons
 - **Exchange rates** - The calculator may need to fetch exchange rates in order to provide accurate currency conversions. How it's done depends on the [configured backend](/calculator#supported-backends)
 - **Typescript extensions** - typescript extensions can make arbitrary network requests. More details about extensions below.
-- **Raycast compatibility** - The Raycast compatbility extension allows to browse the official Raycast store and install extensions published to it.
+- **Raycast compatibility** - The Raycast compatibility extension allows to browse the official Raycast store and install extensions published to it.
 
 ## Typescript Extensions
 

--- a/src/app/window/page.mdx
+++ b/src/app/window/page.mdx
@@ -16,7 +16,7 @@ Further more, it detects opened windows on root search view and allows you to fo
 
 ## Environment Support
 
-Window management support can vary dependbing on the desktop environment or compositor in use. Below is a table showing which environments Vicinae currently supports.
+Window management support can vary depending on the desktop environment or compositor in use. Below is a table showing which environments Vicinae currently supports.
 
 | Name | Supported | Comment |
 |------|-----------|---------|


### PR DESCRIPTION
This PR addresses multiple minor spelling, punctuation, and grammatical mistakes found throughout the documentation files.