### PR TITLE
Fix matugen command according to its manual

### DIFF
--- a/src/app/theming/matugen/page.mdx
+++ b/src/app/theming/matugen/page.mdx
@@ -52,7 +52,7 @@ You can also [view the template](https://raw.githubusercontent.com/vicinaehq/vic
 Once configured, generate a theme from any image:
 
 ```bash
-matugen /path/to/wallpaper.png
+matugen image /path/to/wallpaper.png
 ```
 
 Matugen will:


### PR DESCRIPTION
Matugen command presented in doc doesn't work, here's matugen's help output:
```
Usage: matugen [OPTIONS] <COMMAND>

Commands:
  image  The image to use for generating a color scheme
  color  The source color to use for generating a color scheme
  json   The json file to use and import for templates
  help   Print this message or the help of the given subcommand(s)

Options:
  -t, --type <TYPE>
          Sets a custom color scheme type [default: scheme-tonal-spot] [possible values: scheme-content, scheme-expressive, scheme-fidelity, scheme-fruit-salad, scheme-monochrome, scheme-neutral, scheme-rainbow, scheme-tonal-spot, scheme-vibrant]
  -c, --config <FILE>
          Sets a custom config file
  -p, --prefix <PATH>
          Adds a prefix before paths
      --contrast <CONTRAST>
          Value from -1 to 1. -1 represents minimum contrast, 0 represents standard (i.e. the design as spec'd), and 1 represents maximum contrast
  -v, --verbose

  -q, --quiet
          Whether to show no output
  -d, --debug
          Whether to show debug output
      --include-image-in-json <INCLUDE_IMAGE_IN_JSON>
          Whether to add the image field into json output [possible values: true, false]
  -m, --mode <MODE>
          Which mode to use for the color scheme [default: dark] [possible values: light, dark]
      --dry-run
          Will not generate templates, reload apps, set wallpaper or run any commands
      --show-colors
          Whether to show colors or not
  -j, --json <JSON>
          Whether to dump json of colors [possible values: hex, rgb, rgba, hsl, hsla, strip]
      --import-json <FILE>
          Imports a json file to use as render data (can be used multiple times)
      --import-json-string <STRING>
          Imports a json string to use as render data (can be used multiple times)
  -r, --resize-filter <RESIZE_FILTER>
          Uses a custom resize filter for extracting source color [possible values: nearest, triangle, catmull-rom, gaussian, lanczos3]
  -h, --help
          Print help
  -V, --version
          Print version
```