### PR TITLE
fix(docs): update emoji search deeplink

### DIFF
--- a/src/app/emoji/page.mdx
+++ b/src/app/emoji/page.mdx
@@ -6,7 +6,7 @@ Vicinae ships with a capable emoji picker out of the box.
 
 ## Use emoji picker
 
-Simply launch the [Search Emojis and Symbols](vicinae://extensions/vicinae/vicinae/search-emojis) command.
+Simply launch the [Search Emojis and Symbols](vicinae://extensions/vicinae/core/search-emojis) command.
 
 From there you can copy, pin or add custom keywords to index a specific emoji.
 
@@ -25,3 +25,4 @@ EMOJI_FONT=Twemoji vicinae server
 <Note>
 If the family doesn't exist, a warning will be printed out and the regular emoji font selection logic will apply.
 </Note>
+


### PR DESCRIPTION
It was wrong, updated from `vicinae://extensions/vicinae/vicinae/search-emojis` to `vicinae://extensions/vicinae/core/search-emojis`.