### PR TITLE
Fix typo in extensions creation documentation

### DIFF
--- a/src/app/extensions/create/page.mdx
+++ b/src/app/extensions/create/page.mdx
@@ -8,7 +8,7 @@ In order to develop extensions, you will need:
 
 - A working installation of NodeJS (>=20 recommended). If you are on Linux your package manager may have handled that for you already.
 - A npm compatible package manager such as `npm` or `pnpm`. We always use `npm` in our examples.
-- Basic knowledge of [TypeScript](https://www.typescriptlang.org/) and [React](https://react.dev/). No need to be an expert in order to build simple /extensions.
+- Basic knowledge of [TypeScript](https://www.typescriptlang.org/) and [React](https://react.dev/). No need to be an expert in order to build simple extensions.
 
 ## Create Your Extension
 


### PR DESCRIPTION
just removed unnecesary "/"