### PR TITLE
Rewrite sops-nix secret management documentation

### DIFF
--- a/src/app/nixos/page.mdx
+++ b/src/app/nixos/page.mdx
@@ -165,46 +165,57 @@ To configure extensions with options declaratively, add their configuration as s
 
 This will vary depending on the fields that each extension expects. This is not limited to Vicinae extensions, but also works for any other "entrypoint."
 So Raycast should also be configurable. View the "package.json" for your desired extension to see the options
-### For Sops Users Wishing to declare configs with secrets
 
-This example assumes working knowledge of Sops Nix - Sops-Nix Repo
+### Declaratively Managing Secrets with sops-nix
 
-In your sops secrets file add something similar to this:
-```yaml {{ title: 'secrets.yaml' }}
-vicinae.json: |
-    {
-        "providers": {
-          "@knoopx/nix-0": {
-             "preferences": {
-                "githubToken": "TOKEN HERE"
-             }
-          }
-        }
-    }
+This example assumes that you are familiar with secret management and template management through [sops-nix](https://github.com/Mic92/sops-nix).
+
+In your sops secrets file, add the secrets you want to use in Vicinae.
+```yaml {{ title: 'secrets.sops.yaml' }}
+github: ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-In either your home.nix or your configuration.nix add your sops declaration:
+We're going to use sops-nix's [template feature](https://github.com/Mic92/sops-nix#templates) in this example.
+Templates allow you to generate configuration files dynamically, in Nix, while still keeping the actual secret values encrypted and out of your Nix store.
+You can define individual secrets in your sops file and compose them into structured files using placeholders like `config.sops.placeholder.<secret-name>`.
+At activation time, sops-nix renders the template with the decrypted secret values and writes the final file securely to disk.
+As an additional benefit to this approach, you can still use the secrets elsewhere without needing to declare them multiple times in your sops secrets file.
+
+In either your `home.nix` or your `configuration.nix` add your sops-nix configuration:
 ```nix {{ title: 'home.nix or configuration.nix' }}
+{ config, ... }:
 {
 #...
   sops = {
     secrets = {
-      "vicinae.json" = {
-        owner = username;
+      github = { };
+      # ... - you can add more secrets if needed
+    };
+    templates = {
+      "vicinae-secrets.json" = {  # wrapped in "quotes" because it contains a dot
+        owner = "your-username";  # if you are using `home-manager`, you can omit this
+        content = builtins.toJSON {
+          providers = {
+            "@knoopx/nix" = {  # wrapped in "quotes" because it contains a `@` and a slash
+              preferences = {
+                githubToken = config.sops.placeholder.github; 
+              };
+            };
+          };
+        };
       };
-    #...
     };
   };
 }
 ```
 
-Finally, add your sops secrets as an import:
+Finally, add the sops-nix template file to Vicinae's settings as an import:
 ```nix {{ title: 'home.nix' }}
 {
   services.vicinae.settings = {
     # NOTE: If you have sops configured in your home.nix, it will be config.sops...
     # otherwise, depending on how your nix is configured, it may be nixosConfig.sops...
-    imports = [nixosConfig.sops.secrets."vicinae.json".path];
+    imports = [nixosConfig.sops.templates."vicinae-secrets.json".path];
   };
 }
 ```


### PR DESCRIPTION
I've rewritten part of the sops-nix integration docs to instead provide examples on using [templates](https://github.com/Mic92/sops-nix#templates). Templates provide a number of benefits to the previously suggested method of storing a JSON blob in a sops secrets file, namely that only the secret itself is being stored encrypted. The structure of the secret file doesn't need to be encrypted, just the actual secret value. Additionally, this has composability & reuse benefits, as you don't have to define the same secret value multiple times in your sops config. You can have one `github` secret that you use for multiple applications, for instance.